### PR TITLE
Add markdown syntax highlighting to Uno doc comments

### DIFF
--- a/grammars/uno.cson
+++ b/grammars/uno.cson
@@ -176,6 +176,16 @@
         ]
       }
       {
+        'begin': '/\\*\\*'
+        'end': '\\*/\\n?'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.source.uno'
+        'patterns': [
+          { 'include': 'text.md' }
+        ]
+      }
+      {
         'begin': '/\\*'
         'captures':
           '0':


### PR DESCRIPTION
Up to you if you want to merge this or not, but it really makes the process of writing documentation much less error-prone.

If not, I have no issue with maintaining my own fork, as this plugin is rarely updated.
