### PR TITLE
Add support for switching between editor and designer using shortcut keys

### DIFF
--- a/keymaps/fuse.cson
+++ b/keymaps/fuse.cson
@@ -7,3 +7,10 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
+
+'.platform-win32 atom-text-editor':
+    'ctrl-alt-l': 'fuse:locate-in-designer'
+
+'.platform-darwin atom-text-editor':
+    'cmd-alt-l': 'fuse:locate-in-designer'
+

--- a/lib/daemon.coffee
+++ b/lib/daemon.coffee
@@ -98,14 +98,13 @@ class Daemon extends Disposable
     @daemonConnection.dispose()
 
   class DaemonReconnector extends Disposable
-    constructor: (@fuseLauncher, @msgReceivedCallback, @onConnected) ->
+    constructor: (@fuseLauncher, @msgReceivedCallback, @onReconnected) ->
       super(@dispose)
       @daemonConnection = @connect()
 
     connect: ->
       try
         connection = new DaemonConnection(@fuseLauncher, @msgReceivedCallback, @onLostConnection)
-        @onConnected?()
         return connection
       catch error
         console.log error
@@ -114,6 +113,7 @@ class Daemon extends Disposable
       if not @daemonConnection?
         console.log('fuse: Connects to daemon again.')
         @daemonConnection = @connect()
+        @onReconnected?()
 
       @daemonConnection.send(msgType, serializedMsg)
 

--- a/lib/focusEditor.coffee
+++ b/lib/focusEditor.coffee
@@ -1,0 +1,18 @@
+{Response} = require './messageTypes'
+
+module.exports =
+FocusEditorListener:
+  class FocusEditorListener
+    constructor: (registerRequestListener) ->
+      registerRequestListener 'FocusEditor', @onFocusEditorRequest
+
+    onFocusEditorRequest: (request, responder) ->
+      args = request.arguments
+      console.log "fuse: Bringing focus to " + args.File + "(" + args.Line + "," + args.Column + ")"
+      if atom.project.contains args.Project
+        atom.workspace.open args.File, { initialLine: args.Line - 1, initialColumn: args.Column - 1, searchAllPanes: true }
+        atom.focus()
+        responder new Response(request.id, "Success", [], {})
+      else
+        responder new Response(request.id, "Unhandled", [], {})
+

--- a/lib/fuse.coffee
+++ b/lib/fuse.coffee
@@ -1,4 +1,5 @@
 SelectionChangedNotifier = require './selectionChangedNotifier'
+{FocusEditorListener} = require './focusEditor'
 Daemon = require './daemon'
 UXProvider = require './uxProvider'
 BuildObserver = require './buildObserver'
@@ -46,6 +47,8 @@ module.exports = Fuse =
 
     buildObserver = new BuildObserver @daemon.observeBroadcastedEvents
     @subscriptions.add buildObserver
+
+    focusEditorListener = new FocusEditorListener @daemon.registerRequestListener
 
     errorlistModel = new ErrorListModel buildObserver
     outputModel = new OutputModel buildObserver

--- a/lib/messageTypes.coffee
+++ b/lib/messageTypes.coffee
@@ -53,6 +53,8 @@ Response:
     serialize: ->
       return JSON.stringify({
         Id: @id
+        Status: @status
+        Errors: @errors
         Result: @result
       })
 

--- a/lib/messages.coffee
+++ b/lib/messages.coffee
@@ -40,3 +40,11 @@ GetCodeSuggestionsRequest:
         SyntaxType: args.syntaxType,
         CaretPosition: MessageHelper.convertToCaretPos(args.caretPosition)
       }
+
+PublishServiceRequest:
+  class PublishServiceRequest extends Request
+    constructor: (args) ->
+      super "PublishService", {
+        RequestNames: args.requestNames
+      }
+

--- a/lib/messages.coffee
+++ b/lib/messages.coffee
@@ -48,3 +48,11 @@ PublishServiceRequest:
         RequestNames: args.requestNames
       }
 
+FocusDesignerRequest:
+  class FocusDesignerRequest extends Request
+    constructor: (args) ->
+      super "FocusDesigner", {
+        File: args.file,
+        Line: args.line,
+        Column: args.column
+      }

--- a/menus/fuse.cson
+++ b/menus/fuse.cson
@@ -2,6 +2,10 @@
 'context-menu':
   'atom-text-editor': [
     {
+      label: "Locate in designer"
+      command: "fuse:locate-in-designer"
+    }
+    {
       label: 'Fuse preview'
       submenu: [
         {label: 'Local', command: 'fuse:preview-local'}


### PR DESCRIPTION
Adds support to Atom for handling FocusEditor requests, and sending FocusDesigner requests on shortcut 'Ctrl-Alt-L'

See related internal issue for details.