### PR TITLE
Auto close UX tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Atom Editor plugin for [Fuse](https://www.fusetools.com/).
 * Build and debug output including error list.
 * Selection of UX tags reflected in preview based on caret position.
 * Code completion in UX.
+* Auto closing tags (borrowed from [autoclose](https://github.com/awaw00/autoclose))
 
 ![A screenshot of your package](http://i.imgur.com/pFUfiLe.gif)
 

--- a/lib/autoclose.coffee
+++ b/lib/autoclose.coffee
@@ -1,0 +1,98 @@
+module.exports =
+class AutoCloser
+  currentEditor: null
+  action: null
+  extension: ''
+  autocloseEnabled: true
+
+  constructor: () ->
+    atom.config.observe 'fuse.autocloseEnabled', (value) =>
+      @autocloseEnabled = value
+
+    @currentEditor = atom.workspace.getActiveTextEditor()
+    if @currentEditor
+      @action = @currentEditor.onDidInsertText (event) =>
+        @closeTag(event)
+    @getFileExtension()
+    atom.workspace.onDidChangeActivePaneItem (paneItem) =>
+      @paneItemChanged(paneItem)
+
+  deactivate: () ->
+    if @action then @action.disposalAction()
+
+  getFileExtension: ->
+    filename = @currentEditor?.getFileName?()
+    @extension = filename?.substr filename?.lastIndexOf('.') + 1
+
+  paneItemChanged: (paneItem) ->
+    if !paneItem then return
+
+    if @action then @action.disposalAction()
+    @currentEditor = paneItem
+    @getFileExtension()
+    if @currentEditor.onDidInsertText
+      @action = @currentEditor.onDidInsertText (event) =>
+        @closeTag(event)
+
+  addIntent: (range) ->
+    {start, end} = range
+    buffer = @currentEditor.buffer
+    lineBefore = buffer.getLines()[start.row]
+    lineAfter = buffer.getLines()[end.row]
+    content = lineBefore.substr(lineBefore.lastIndexOf('<')) + '\n' + lineAfter
+    regex = ///
+              ^.*\<([a-zA-Z-_]+)(\s.+)?\>
+              \n
+              \s*\<\/\1\>.*
+            ///
+
+    if regex.test content
+      @currentEditor.insertNewlineAbove()
+      @currentEditor.insertText('  ')
+
+  closeTag: (event) ->
+    return if not @autocloseEnabled
+    return if @extension isnt "ux"
+
+    {text, range} = event
+    if text is '\n'
+      @addIntent event.range
+      return
+
+    return if text isnt '>' and text isnt '/'
+
+    line = @currentEditor.buffer.getLines()[range.end.row]
+    strBefore = line.substr 0, range.start.column
+    strAfter = line.substr range.end.column
+    previousTagIndex = strBefore.lastIndexOf('<')
+
+    if previousTagIndex < 0
+      return
+
+    tagName = strBefore.match(/^.*\<([a-zA-Z-_.]+)[^>]*?/)?[1]
+    if !tagName then return
+
+    if text is '>'
+      if strBefore[strBefore.length - 1] is '/'
+        return
+
+      # dont close if its already close by />
+      if strBefore.substr(strBefore.length - 2) is "/>"
+        return
+
+      # dont close if already closed by </tagName>
+      if strAfter.indexOf("</#{tagName}>") isnt -1
+        return
+
+      @currentEditor.insertText "</#{tagName}>"
+      @currentEditor.moveLeft tagName.length + 3
+    else if text is '/'
+      if strAfter[0] is '>'
+        closingTagIndex = strAfter.indexOf("</#{tagName}>")
+        if closingTagIndex isnt -1
+          @currentEditor.moveToEndOfLine()
+          @currentEditor.selectLeft("</#{tagName}>".length)
+          @currentEditor.delete()
+          @currentEditor.moveLeft 2
+      else
+        @currentEditor.insertText '>'

--- a/lib/fuse.coffee
+++ b/lib/fuse.coffee
@@ -12,14 +12,12 @@ FuseLauncher = require './fuseLauncher'
 Preview = require './preview'
 Path = require 'path'
 {OutputView, LogEvent, OutputModel} = require './outputView'
+AutoCloser = require './autoclose'
 
 module.exports = Fuse =
-  currentEditor: null
-  action: null
-  extension: ''
-  enabledFileExtensions: []
   subscriptions: null
   daemon: null
+  autoCloser: null
 
   config:
     fuseCommand:
@@ -30,11 +28,10 @@ module.exports = Fuse =
       type: 'boolean'
       default: 'true'
       description: 'Enable selection of UX tags reflected in preview based on caret position.'
-    enabledFileExtensions:
-      type: 'array',
-      default: ['ux'],
-      description: 'Enabled only in UX files'
-
+    autocloseEnabled:
+      type: 'boolean',
+      default: true,
+      description: 'Enable auto closing of UX tags.'
 
   activate: (state) ->
     console.log('fuse: Starting fuse.')
@@ -90,17 +87,7 @@ module.exports = Fuse =
 
     @uxProvider = new UXProvider @daemon
 
-    # AUTOCLOSE STUFF
-    atom.config.observe 'fuse.enabledFileExtensions', (value) =>
-      @enabledFileExtensions = value
-
-    @currentEditor = atom.workspace.getActiveTextEditor()
-    if @currentEditor
-      @action = @currentEditor.onDidInsertText (event) =>
-        @_closeTag(event)
-    @_getFileExtension()
-    atom.workspace.onDidChangeActivePaneItem (paneItem) =>
-      @_paneItemChanged(paneItem)
+    @autoCloser = new AutoCloser
 
   previewWithOutput: (fuseLauncher, target, path, output) ->
     p = Preview.run(fuseLauncher, target, path)
@@ -133,85 +120,9 @@ module.exports = Fuse =
     @uxProvider
 
   deactivate: ->
-    if @action then @action.disposalAction()
     @subscriptions?.dispose()
     @fuseBottomPanel?.destroy()
+    @autoCloser?.deactivate()
 
   serialize: ->
     fuseBottomPanel: @fuseBottomPanel?.serialize()
-
-  _getFileExtension: ->
-    filename = @currentEditor?.getFileName?()
-    @extension = filename?.substr filename?.lastIndexOf('.') + 1
-
-  _paneItemChanged: (paneItem) ->
-    if !paneItem then return
-
-    if @action then @action.disposalAction()
-    @currentEditor = paneItem
-    @_getFileExtension()
-    if @currentEditor.onDidInsertText
-      @action = @currentEditor.onDidInsertText (event) =>
-        @_closeTag(event)
-
-  _addIndent: (range) ->
-    {start, end} = range
-    buffer = @currentEditor.buffer
-    lineBefore = buffer.getLines()[start.row]
-    lineAfter = buffer.getLines()[end.row]
-    content = lineBefore.substr(lineBefore.lastIndexOf('<')) + '\n' + lineAfter
-    regex = ///
-              ^.*\<([a-zA-Z-_]+)(\s.+)?\>
-              \n
-              \s*\<\/\1\>.*
-            ///
-
-    if regex.test content
-      @currentEditor.insertNewlineAbove()
-      @currentEditor.insertText('  ')
-
-  _closeTag: (event) ->
-    return if @extension not in @enabledFileExtensions
-
-    {text, range} = event
-    if text is '\n'
-      @_addIndent event.range
-      return
-
-    return if text isnt '>' and text isnt '/'
-
-    line = @currentEditor.buffer.getLines()[range.end.row]
-    strBefore = line.substr 0, range.start.column
-    strAfter = line.substr range.end.column
-    previousTagIndex = strBefore.lastIndexOf('<')
-
-    if previousTagIndex < 0
-      return
-
-    tagName = strBefore.match(/^.*\<([a-zA-Z-_.]+)[^>]*?/)?[1]
-    if !tagName then return
-
-    if text is '>'
-      if strBefore[strBefore.length - 1] is '/'
-        return
-
-      # dont close if its already close by />
-      if strBefore.substr(strBefore.length - 2) is "/>"
-        return
-
-      # dont close if already closed by </tagName>
-      if strAfter.indexOf("</#{tagName}>") isnt -1
-        return
-
-      @currentEditor.insertText "</#{tagName}>"
-      @currentEditor.moveLeft tagName.length + 3
-    else if text is '/'
-      if strAfter[0] is '>'
-        closingTagIndex = strAfter.indexOf("</#{tagName}>")
-        if closingTagIndex isnt -1
-          @currentEditor.moveToEndOfLine()
-          @currentEditor.selectLeft("</#{tagName}>".length)
-          @currentEditor.delete()
-          @currentEditor.moveLeft 2
-      else
-        @currentEditor.insertText '>'

--- a/lib/fuse.coffee
+++ b/lib/fuse.coffee
@@ -91,7 +91,6 @@ module.exports = Fuse =
     @uxProvider = new UXProvider @daemon
 
     # AUTOCLOSE STUFF
-
     atom.config.observe 'fuse.enabledFileExtensions', (value) =>
       @enabledFileExtensions = value
 
@@ -134,11 +133,9 @@ module.exports = Fuse =
     @uxProvider
 
   deactivate: ->
+    if @action then @action.disposalAction()
     @subscriptions?.dispose()
     @fuseBottomPanel?.destroy()
-
-    if @action then @action.disposalAction()
-    @subscriptions.dispose()
 
   serialize: ->
     fuseBottomPanel: @fuseBottomPanel?.serialize()


### PR DESCRIPTION
Regarding: #28

I borrowed some code from https://github.com/awaw00/autoclose and added a few fixes, which makes it more convenient to use. 

Features:
* Typing **>** after `<TAG` auto closes with `</TAG>`
* Typing **/** after `<TAG` auto closes with `>`
* Typing **/** inside of `<TAG></TAG>` removes `</TAG>` (only if in the same line)