### PR TITLE
fail gracefully when deamon is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.1
+- Fixed a problem during start-up when the Fuse daemon couldn't be started. We now log a warning instead of crashing.
+
 # 0.4.0
 - Fixed auto-indentation in UX and Unoproj
 

--- a/lib/daemonConnection.coffee
+++ b/lib/daemonConnection.coffee
@@ -25,6 +25,11 @@ module.exports =
         @onExit?()
       )
 
+      @fuseClient.on('error', =>
+        console.log 'fuse: deamon failed to start'
+        @onExit?()
+      )
+
     parseMsgFromBuffer: (buffer, msgCallback) =>
       start = 0
       while start < buffer.length


### PR DESCRIPTION
If Fuse isn't installed, we currently crash hard, pulling up the
development menu of Atom. Instead, let's handle the error and emit
a warning in the log.